### PR TITLE
Fix documentation rules

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,11 +2,13 @@
 # by only invoking hadrian.
 
 
-{ nixpkgs ? import <nixpkgs> {} }:
+{ nixpkgs ? import <nixpkgs> {}
+, boot-ghc ? "ghc821" }:
 
 let
-  haskellPackages = nixpkgs.haskell.packages.ghc821;
-
+  ourtexlive = nixpkgs.texlive.combine
+    { inherit (nixpkgs.texlive) scheme-small fncychap; };
+  haskellPackages = nixpkgs.haskell.packages.${boot-ghc};
   removeBuild = path: type:
     let baseName = baseNameOf (toString path);
     in
@@ -20,33 +22,35 @@ let
            || nixpkgs.lib.hasSuffix ".sh" baseName
            || !(nixpkgs.lib.cleanSourceFilter path type)) ;
 
-  filterSrc = path: builtins.filterSource removeBuild path;
+  filterSrc = path: builtins.filterSource removeBuild path ;
 
-
-  hadrianPackages = nixpkgs.haskell.packages.ghc821.override {
+  hadrianPackages = haskellPackages.override {
     overrides = self: super: let
-        localPackage = name: path: self.callCabal2nix name (filterSrc path) {};
+        localPackage = name: path: self.callCabal2nix name (filterSrc path) {} ;
+	noCheck = nixpkgs.haskell.lib.dontCheck ;
       in {
         hadrian = localPackage "hadrian" ./. ;
-        shake = self.callHackage "shake" "0.16" {};
-        Cabal = localPackage "Cabal" ./../libraries/Cabal/Cabal ;
-        filepath = localPackage "filepath" ./../libraries/filepath ;
-        text = localPackage "text" ./../libraries/text  ;
-        hpc = localPackage"hpc" ./../libraries/hpc ;
-        parsec = localPackage "parsec" ./../libraries/parsec ;
-        HUnit = nixpkgs.haskell.lib.dontCheck (self.callHackage "HUnit" "1.3.1.2" {});
-        process = localPackage "process" ./../libraries/process ;
-        directory = localPackage "directory" ./../libraries/directory ;
+        shake = noCheck (self.callHackage "shake" "0.16" {}) ;
+        Cabal = noCheck (localPackage "Cabal" ./../libraries/Cabal/Cabal) ;
+        filepath = noCheck (localPackage "filepath" ./../libraries/filepath) ;
+        text = noCheck (localPackage "text" ./../libraries/text) ;
+        hpc = noCheck (localPackage "hpc" ./../libraries/hpc) ;
+        parsec = noCheck (localPackage "parsec" ./../libraries/parsec) ;
+        HUnit = noCheck (self.callHackage "HUnit" "1.3.1.2" {}) ;
+        process = noCheck (localPackage "process" ./../libraries/process) ;
+        directory = noCheck (localPackage "directory" ./../libraries/directory) ;
       }; };
 
 in
-  nixpkgs.lib.overrideDerivation nixpkgs.haskell.packages.ghcHEAD.ghc
+  nixpkgs.lib.overrideDerivation
+    (nixpkgs.haskell.compiler.ghcHEAD.override {
+      bootPkgs = haskellPackages;
+    })
     (drv: {
       name = "ghc-dev";
       buildInputs = drv.buildInputs ++ [
                     hadrianPackages.hadrian
                     nixpkgs.arcanist
-                    nixpkgs.haskell.compiler.ghc821
                     haskellPackages.alex
                     haskellPackages.happy
                     nixpkgs.python3
@@ -61,5 +65,6 @@ in
                     nixpkgs.gmp
                     nixpkgs.file
                     nixpkgs.llvm_5
+		    ourtexlive
 		  ];
-  }
+  })

--- a/src/Hadrian/Haskell/Cabal/Parse.hs
+++ b/src/Hadrian/Haskell/Cabal/Parse.hs
@@ -265,6 +265,7 @@ parseConfiguredCabal context@Context {..} = do
       , modules  = map C.display . snd . biModules $ pd'
       , otherModules = map C.display . C.otherModules . fst . biModules $ pd'
       , synopsis = C.synopsis pd'
+      , description = C.description pd'
       , srcDirs = C.hsSourceDirs . fst . biModules $ pd'
       , deps = deps
       , depIpIds = dep_ipids

--- a/src/Rules/Documentation.hs
+++ b/src/Rules/Documentation.hs
@@ -109,6 +109,11 @@ buildLibraryDocumentation :: Rules ()
 buildLibraryDocumentation = do
     root <- buildRootRules
     root -/- htmlRoot -/- "libraries/index.html" %> \file -> do
+        -- If we omit this, the 'docs' rule fails with an error
+        -- complaining about this file not being there:
+        -- https://gist.github.com/alpmestan/f0709cdf001efe1dd35ed1c7a216fc71
+        -- when running e.g:
+        -- hadrian/build.nix.sh --flavour=quick-with-ng -j3 docs
         need [ root -/- "stage1/lib/llvm-targets" ]
         haddocks <- allHaddocks
         let libDocs = filter (\x -> takeFileName x `notElem` [ "ghc.haddock"

--- a/src/Settings/Builders/Haddock.hs
+++ b/src/Settings/Builders/Haddock.hs
@@ -7,20 +7,23 @@ import Rules.Documentation
 import Settings.Builders.Common
 import Settings.Builders.Ghc
 import Types.ConfiguredCabal as ConfCabal
+import qualified Types.Context
 
 -- | Given a version string such as "2.16.2" produce an integer equivalent.
 versionToInt :: String -> Int
-versionToInt s = case map read . words $ replaceEq '.' ' ' s of
-    [major, minor, patch] -> major * 1000 + minor * 10 + patch
-    _                     -> error "versionToInt: cannot parse version."
+versionToInt = read . dropWhile (=='0') . filter (/='.')
 
 haddockBuilderArgs :: Args
 haddockBuilderArgs = withHsPackage $ \ctx -> mconcat
     [ builder (Haddock BuildIndex) ? do
         output <- getOutput
         inputs <- getInputs
+        root   <- getBuildRoot
+        stg    <- Types.Context.stage <$> getContext
         mconcat
-            [ arg "--gen-index"
+            [ arg $ "-B" ++ root -/- "stage1" -/- "lib"
+            , arg $ "--lib=" ++ root -/- "lib"
+            , arg "--gen-index"
             , arg "--gen-contents"
             , arg "-o", arg $ takeDirectory output
             , arg "-t", arg "Haskell Hierarchical Libraries"
@@ -33,6 +36,8 @@ haddockBuilderArgs = withHsPackage $ \ctx -> mconcat
         output   <- getOutput
         pkg      <- getPackage
         path     <- getBuildPath
+        root     <- getBuildRoot
+        stg      <- Types.Context.stage <$> getContext
         Just version  <- expr $ pkgVersion  ctx
         Just synopsis <- expr $ pkgSynopsis ctx
         deps     <- getConfiguredCabalData ConfCabal.depNames
@@ -40,7 +45,9 @@ haddockBuilderArgs = withHsPackage $ \ctx -> mconcat
         Just hVersion <- expr $ pkgVersion ctx
         ghcOpts  <- haddockGhcArgs
         mconcat
-            [ arg $ "--odir=" ++ takeDirectory output
+            [ arg $ "-B" ++ root -/- "stage1" -/- "lib"
+            , arg $ "--lib=" ++ root -/- "lib"
+            , arg $ "--odir=" ++ takeDirectory output
             , arg "--verbosity=0"
             , arg "--no-tmp-comp-dir"
             , arg $ "--dump-interface=" ++ output
@@ -49,14 +56,14 @@ haddockBuilderArgs = withHsPackage $ \ctx -> mconcat
             , arg "--hoogle"
             , arg $ "--title=" ++ pkgName pkg ++ "-" ++ version
                     ++ ": " ++ synopsis
-            , arg $ "--prologue=" ++ path -/- "haddock-prologue.txt"
+            , arg $ "--prologue=" ++ takeDirectory output -/- "haddock-prologue.txt"
             , arg $ "--optghc=-D__HADDOCK_VERSION__="
                     ++ show (versionToInt hVersion)
             , map ("--hide=" ++) <$> getConfiguredCabalData ConfCabal.otherModules
             , pure [ "--read-interface=../" ++ dep
                      ++ ",../" ++ dep ++ "/src/%{MODULE}.html#%{NAME},"
                      ++ haddock | (dep, haddock) <- zip deps haddocks ]
-            , pure [ "--optghc=" ++ opt | opt <- ghcOpts ]
+            , pure [ "--optghc=" ++ opt | opt <- ghcOpts, not ("--package-db" `isInfixOf` opt) ]
             , getInputs
             , arg "+RTS"
             , arg $ "-t" ++ path -/- "haddock.t"

--- a/src/Types/ConfiguredCabal.hs
+++ b/src/Types/ConfiguredCabal.hs
@@ -14,6 +14,7 @@ data ConfiguredCabal = ConfiguredCabal
     , modules      :: [String]
     , otherModules :: [String]
     , synopsis     :: String
+    , description  :: String
     , srcDirs      :: [String]
     , deps         :: [String]
     , depIpIds     :: [String]
@@ -47,8 +48,8 @@ instance Hashable ConfiguredCabal where
 
 instance NFData ConfiguredCabal where
     rnf (ConfiguredCabal a b c d e f g h i j k l m n o p q r s t u v w x z y
-          aa ab ac ad ae)
+          aa ab ac ad ae af)
       = a `seq` b `seq` c `seq` d `seq` e `seq` f `seq` g `seq` h `seq` i `seq` j
         `seq` k `seq` l `seq` m `seq` n `seq` o `seq` p `seq` q `seq` r `seq` s `seq` t
         `seq` u `seq` v `seq` w `seq` x `seq` y `seq` z `seq` aa `seq` ab `seq` ac `seq` ad
-        `seq` ae `seq` ()
+        `seq` ae `seq` af `seq` ()


### PR DESCRIPTION
I have some trouble building the PDFs on my machine because I can't get xelatex to find fncychap.sty. But the rule seems to fire just fine so I'm hoping this will work on other people's machines.

To test this, simply run the `docs` target.