### PR TITLE
Ship docs in binary distributions

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,11 +2,13 @@
 # by only invoking hadrian.
 
 
-{ nixpkgs ? import <nixpkgs> {} }:
+{ nixpkgs ? import <nixpkgs> {}
+, boot-ghc ? "ghc821" }:
 
 let
-  haskellPackages = nixpkgs.haskell.packages.ghc821;
-
+  ourtexlive = nixpkgs.texlive.combine
+    { inherit (nixpkgs.texlive) scheme-small fncychap; };
+  haskellPackages = nixpkgs.haskell.packages.${boot-ghc};
   removeBuild = path: type:
     let baseName = baseNameOf (toString path);
     in
@@ -20,33 +22,35 @@ let
            || nixpkgs.lib.hasSuffix ".sh" baseName
            || !(nixpkgs.lib.cleanSourceFilter path type)) ;
 
-  filterSrc = path: builtins.filterSource removeBuild path;
+  filterSrc = path: builtins.filterSource removeBuild path ;
 
-
-  hadrianPackages = nixpkgs.haskell.packages.ghc821.override {
+  hadrianPackages = haskellPackages.override {
     overrides = self: super: let
-        localPackage = name: path: self.callCabal2nix name (filterSrc path) {};
+        localPackage = name: path: self.callCabal2nix name (filterSrc path) {} ;
+	noCheck = nixpkgs.haskell.lib.dontCheck ;
       in {
         hadrian = localPackage "hadrian" ./. ;
-        shake = self.callHackage "shake" "0.16" {};
-        Cabal = localPackage "Cabal" ./../libraries/Cabal/Cabal ;
-        filepath = localPackage "filepath" ./../libraries/filepath ;
-        text = localPackage "text" ./../libraries/text  ;
-        hpc = localPackage"hpc" ./../libraries/hpc ;
-        parsec = localPackage "parsec" ./../libraries/parsec ;
-        HUnit = nixpkgs.haskell.lib.dontCheck (self.callHackage "HUnit" "1.3.1.2" {});
-        process = localPackage "process" ./../libraries/process ;
-        directory = localPackage "directory" ./../libraries/directory ;
+        shake = noCheck (self.callHackage "shake" "0.16" {}) ;
+        Cabal = noCheck (localPackage "Cabal" ./../libraries/Cabal/Cabal) ;
+        filepath = noCheck (localPackage "filepath" ./../libraries/filepath) ;
+        text = noCheck (localPackage "text" ./../libraries/text) ;
+        hpc = noCheck (localPackage "hpc" ./../libraries/hpc) ;
+        parsec = noCheck (localPackage "parsec" ./../libraries/parsec) ;
+        HUnit = noCheck (self.callHackage "HUnit" "1.3.1.2" {}) ;
+        process = noCheck (localPackage "process" ./../libraries/process) ;
+        directory = noCheck (localPackage "directory" ./../libraries/directory) ;
       }; };
 
 in
-  nixpkgs.lib.overrideDerivation nixpkgs.haskell.packages.ghcHEAD.ghc
+  nixpkgs.lib.overrideDerivation
+    (nixpkgs.haskell.compiler.ghcHEAD.override {
+      bootPkgs = haskellPackages;
+    })
     (drv: {
       name = "ghc-dev";
       buildInputs = drv.buildInputs ++ [
                     hadrianPackages.hadrian
                     nixpkgs.arcanist
-                    nixpkgs.haskell.compiler.ghc821
                     haskellPackages.alex
                     haskellPackages.happy
                     nixpkgs.python3
@@ -61,5 +65,6 @@ in
                     nixpkgs.gmp
                     nixpkgs.file
                     nixpkgs.llvm_5
+		    ourtexlive
 		  ];
-  }
+  })

--- a/src/Hadrian/Haskell/Cabal/Parse.hs
+++ b/src/Hadrian/Haskell/Cabal/Parse.hs
@@ -265,6 +265,7 @@ parseConfiguredCabal context@Context {..} = do
       , modules  = map C.display . snd . biModules $ pd'
       , otherModules = map C.display . C.otherModules . fst . biModules $ pd'
       , synopsis = C.synopsis pd'
+      , description = C.description pd'
       , srcDirs = C.hsSourceDirs . fst . biModules $ pd'
       , deps = deps
       , depIpIds = dep_ipids

--- a/src/Rules.hs
+++ b/src/Rules.hs
@@ -52,17 +52,23 @@ topLevelTargets = do
       buildWithCmdOptions [Cwd $ cwd -/- "distrib"] $
         target (vanillaContext Stage1 ghc) (Autoreconf $ cwd -/- "distrib") [] []
 
+      let ghcVersionPretty = "ghc-" ++ version ++ "-" ++ targetPlatform
+          bindistFilesDir  = baseDir -/- ghcVersionPretty
+      createDirectory bindistFilesDir
+
       -- copy config.sub, config.guess, install-sh, Makefile files, etc
       -- from the source of the tree to the bindist dir
-      copyFile (cwd -/- "distrib" -/- "configure") (baseDir -/- "configure")
-      copyFile (cwd -/- "distrib" -/- "Makefile") (baseDir -/- "Makefile")
-      copyFile (cwd -/- "install-sh") (baseDir -/- "install-sh")
-      copyFile (cwd -/- "config.sub") (baseDir -/- "config.sub")
-      copyFile (cwd -/- "config.guess") (baseDir -/- "config.guess")
-      copyFile (cwd -/- "settings.in") (baseDir -/- "settings.in")
-      copyFile (cwd -/- "mk" -/- "config.mk.in") (baseDir -/- "mk" -/- "config.mk.in")
-      copyFile (cwd -/- "mk" -/- "install.mk.in") (baseDir -/- "mk" -/- "install.mk.in")
-      copyDirectory (takeDirectory baseDir -/- "docs") baseDir
+      copyFile (cwd -/- "distrib" -/- "configure") (bindistFilesDir -/- "configure")
+      copyFile (cwd -/- "distrib" -/- "Makefile") (bindistFilesDir -/- "Makefile")
+      copyFile (cwd -/- "install-sh") (bindistFilesDir -/- "install-sh")
+      copyFile (cwd -/- "config.sub") (bindistFilesDir -/- "config.sub")
+      copyFile (cwd -/- "config.guess") (bindistFilesDir -/- "config.guess")
+      copyFile (cwd -/- "settings.in") (bindistFilesDir -/- "settings.in")
+      copyFile (cwd -/- "mk" -/- "config.mk.in") (bindistFilesDir -/- "mk" -/- "config.mk.in")
+      copyFile (cwd -/- "mk" -/- "install.mk.in") (bindistFilesDir -/- "mk" -/- "install.mk.in")
+      copyDirectory (baseDir -/- "bin") bindistFilesDir
+      copyDirectory (baseDir -/- "lib") bindistFilesDir
+      copyDirectory (takeDirectory baseDir -/- "docs") bindistFilesDir
 
       -- TODO: move stage1/bin, stage1/lib and all the files above to some
       --       other (temporary?) directory, and invoke tar there
@@ -71,11 +77,12 @@ topLevelTargets = do
       buildWithCmdOptions [Cwd baseDir] $
         -- ghc is a fake package here.
         target (vanillaContext Stage1 ghc) (Tar Create)
-               [ "bin", "lib", "docs", "configure", "config.sub", "config.guess"
+               [ ghcVersionPretty ]
+               {- [ "bin", "lib", "docs", "configure", "config.sub", "config.guess"
                , "install-sh", "settings.in", "mk/config.mk.in", "mk/install.mk.in"
                , "Makefile"
-               ]
-               [binDistDir -/- "ghc-" ++ version ++ "-" ++ targetPlatform ++ ".tar.xz"]
+               ] -}
+               [binDistDir -/- ghcVersionPretty ++ ".tar.xz"]
 
     phony "stage2" $ do
       putNormal "Building stage2"

--- a/src/Rules.hs
+++ b/src/Rules.hs
@@ -40,7 +40,7 @@ topLevelTargets = do
       -- Instead we should *need* the libraries and binaries we want to
       -- put into the binary distribution.  For now we will just *need*
       -- stage2 and package up bin and lib.
-      need ["stage2"]
+      need ["stage2", "docs"]
       version <- setting ProjectVersion
       cwd <- liftIO getCurrentDirectory
       binDistDir <- getEnvWithDefault cwd "BINARY_DIST_DIR"
@@ -62,11 +62,16 @@ topLevelTargets = do
       copyFile (cwd -/- "settings.in") (baseDir -/- "settings.in")
       copyFile (cwd -/- "mk" -/- "config.mk.in") (baseDir -/- "mk" -/- "config.mk.in")
       copyFile (cwd -/- "mk" -/- "install.mk.in") (baseDir -/- "mk" -/- "install.mk.in")
+      copyDirectory (takeDirectory baseDir -/- "docs") baseDir
+
+      -- TODO: move stage1/bin, stage1/lib and all the files above to some
+      --       other (temporary?) directory, and invoke tar there
+      -- TODO: test with another flavour than quick-with-ng
 
       buildWithCmdOptions [Cwd baseDir] $
-        -- ghc is a fake packge here.
+        -- ghc is a fake package here.
         target (vanillaContext Stage1 ghc) (Tar Create)
-               [ "bin", "lib", "configure", "config.sub", "config.guess"
+               [ "bin", "lib", "docs", "configure", "config.sub", "config.guess"
                , "install-sh", "settings.in", "mk/config.mk.in", "mk/install.mk.in"
                , "Makefile"
                ]

--- a/src/Rules/Documentation.hs
+++ b/src/Rules/Documentation.hs
@@ -31,7 +31,7 @@ documentationRules = do
         let html = htmlRoot -/- "index.html"
             archives = map pathArchive docPaths
             pdfs = map pathPdf $ docPaths \\ [ "libraries" ]
-        need $ map (root -/-) $ [html] ++ archives ++ pdfs
+        need $ map (root -/-) $ [html] ++ archives -- ++ pdfs
         need [ root -/- htmlRoot -/- "libraries" -/- "gen_contents_index" ]
         need [ root -/- htmlRoot -/- "libraries" -/- "prologue.txt" ]
         need [manPagePath]

--- a/src/Settings/Builders/Haddock.hs
+++ b/src/Settings/Builders/Haddock.hs
@@ -7,20 +7,23 @@ import Rules.Documentation
 import Settings.Builders.Common
 import Settings.Builders.Ghc
 import Types.ConfiguredCabal as ConfCabal
+import qualified Types.Context
 
 -- | Given a version string such as "2.16.2" produce an integer equivalent.
 versionToInt :: String -> Int
-versionToInt s = case map read . words $ replaceEq '.' ' ' s of
-    [major, minor, patch] -> major * 1000 + minor * 10 + patch
-    _                     -> error "versionToInt: cannot parse version."
+versionToInt = read . dropWhile (=='0') . filter (/='.')
 
 haddockBuilderArgs :: Args
 haddockBuilderArgs = withHsPackage $ \ctx -> mconcat
     [ builder (Haddock BuildIndex) ? do
         output <- getOutput
         inputs <- getInputs
+        root   <- getBuildRoot
+        stg    <- Types.Context.stage <$> getContext
         mconcat
-            [ arg "--gen-index"
+            [ arg $ "-B" ++ root -/- "stage1" -/- "lib"
+            , arg $ "--lib=" ++ root -/- "lib"
+            , arg "--gen-index"
             , arg "--gen-contents"
             , arg "-o", arg $ takeDirectory output
             , arg "-t", arg "Haskell Hierarchical Libraries"
@@ -33,6 +36,8 @@ haddockBuilderArgs = withHsPackage $ \ctx -> mconcat
         output   <- getOutput
         pkg      <- getPackage
         path     <- getBuildPath
+        root     <- getBuildRoot
+        stg      <- Types.Context.stage <$> getContext
         Just version  <- expr $ pkgVersion  ctx
         Just synopsis <- expr $ pkgSynopsis ctx
         deps     <- getConfiguredCabalData ConfCabal.depNames
@@ -40,7 +45,9 @@ haddockBuilderArgs = withHsPackage $ \ctx -> mconcat
         Just hVersion <- expr $ pkgVersion ctx
         ghcOpts  <- haddockGhcArgs
         mconcat
-            [ arg $ "--odir=" ++ takeDirectory output
+            [ arg $ "-B" ++ root -/- "stage1" -/- "lib"
+            , arg $ "--lib=" ++ root -/- "lib"
+            , arg $ "--odir=" ++ takeDirectory output
             , arg "--verbosity=0"
             , arg "--no-tmp-comp-dir"
             , arg $ "--dump-interface=" ++ output
@@ -49,14 +56,14 @@ haddockBuilderArgs = withHsPackage $ \ctx -> mconcat
             , arg "--hoogle"
             , arg $ "--title=" ++ pkgName pkg ++ "-" ++ version
                     ++ ": " ++ synopsis
-            , arg $ "--prologue=" ++ path -/- "haddock-prologue.txt"
+            , arg $ "--prologue=" ++ takeDirectory output -/- "haddock-prologue.txt"
             , arg $ "--optghc=-D__HADDOCK_VERSION__="
                     ++ show (versionToInt hVersion)
             , map ("--hide=" ++) <$> getConfiguredCabalData ConfCabal.otherModules
             , pure [ "--read-interface=../" ++ dep
                      ++ ",../" ++ dep ++ "/src/%{MODULE}.html#%{NAME},"
                      ++ haddock | (dep, haddock) <- zip deps haddocks ]
-            , pure [ "--optghc=" ++ opt | opt <- ghcOpts ]
+            , pure [ "--optghc=" ++ opt | opt <- ghcOpts, not ("--package-db" `isInfixOf` opt) ]
             , getInputs
             , arg "+RTS"
             , arg $ "-t" ++ path -/- "haddock.t"

--- a/src/Types/ConfiguredCabal.hs
+++ b/src/Types/ConfiguredCabal.hs
@@ -14,6 +14,7 @@ data ConfiguredCabal = ConfiguredCabal
     , modules      :: [String]
     , otherModules :: [String]
     , synopsis     :: String
+    , description  :: String
     , srcDirs      :: [String]
     , deps         :: [String]
     , depIpIds     :: [String]
@@ -47,8 +48,8 @@ instance Hashable ConfiguredCabal where
 
 instance NFData ConfiguredCabal where
     rnf (ConfiguredCabal a b c d e f g h i j k l m n o p q r s t u v w x z y
-          aa ab ac ad ae)
+          aa ab ac ad ae af)
       = a `seq` b `seq` c `seq` d `seq` e `seq` f `seq` g `seq` h `seq` i `seq` j
         `seq` k `seq` l `seq` m `seq` n `seq` o `seq` p `seq` q `seq` r `seq` s `seq` t
         `seq` u `seq` v `seq` w `seq` x `seq` y `seq` z `seq` aa `seq` ab `seq` ac `seq` ad
-        `seq` ae `seq` ()
+        `seq` ae `seq` af `seq` ()


### PR DESCRIPTION
This patch makes the `binary-dist` rule `need` the docs and packs them up into an archive along with everything else. While I was at it, I implemented a tiny change that creates a tar archive of a single folder, so that when we extract the archive, we don't get all the files filling the current directory but instead get a clean, single new folder with everything in it.

This is based on top of the patch from #2 and will have to be rebased once that PR is merged.

In order to test this patch, just run the `binary-dist` rule and then you should get a ghc bindist that you can extract and play around with.